### PR TITLE
update discord.js version on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "homepage": "https://livelysource.tk/",
   "dependencies": {
-    "discord.js": "^11.4.2",
+    "discord.js": "^12.5.3",
     "fs": "0.0.1-security"
   }
 }


### PR DESCRIPTION
Solution: Update Discord.js to v12

Why does this error occur?
Your bot encountered a Stage Channel, Discord.js v11 does not - and will not - support stage channels. This is essentially the end of the road for v11.

Statement by Discord.js maintainers

Version 11 will hard crash if it encounters a stage channel
• we will not fix this
• please update your bot to version 12 https://v12.discordjs.guide/additional-info/changes-in-v12.html#before-you-start
• reminder: logging in with a user token is against discord terms of service and we fully dropped support for user accounts in version 12.

[source](https://stackoverflow.com/questions/67610078/guild-channels-setchannel-id-channel-cannot-read-property-id-of-undefined)